### PR TITLE
Migrate to esm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ npm-debug.log
 *.orig
 .DS_Store
 *.bak
+index.cjs.js

--- a/index.esm.js
+++ b/index.esm.js
@@ -1,7 +1,4 @@
-module.exports = stifle;
-
-
-function stifle (fn, wait) {
+export default function stifle (fn, wait) {
   if (typeof fn !== 'function' || typeof wait !== 'number') {
     throw new Error('stifle(fn, wait) -- expected a function and number of milliseconds, got (' + typeof fn + ', ' + typeof wait + ')');
   }

--- a/package.json
+++ b/package.json
@@ -2,15 +2,24 @@
   "name": "stifle",
   "version": "1.0.4",
   "description": "A very simple way to throttle a function",
-  "main": "index.js",
+  "main": "index.cjs.js",
+  "module": "index.esm.js",
+  "files": [
+    "index.cjs.js",
+    "index.esm.js"
+  ],
   "repository": "https://github.com/twobitfool/stifle",
   "author": "Matt Smith <matt@twobitfool.com>",
   "license": "MIT",
   "scripts": {
-    "test": "mocha"
+    "build": "rollup -i index.esm.js -o index.cjs.js -f cjs",
+    "test": "mocha -r esm",
+    "prepublish": "yarn build"
   },
   "devDependencies": {
     "chai": "^3.5.0",
-    "mocha": "^3.3.0"
+    "esm": "^3.0.36",
+    "mocha": "^3.3.0",
+    "rollup": "^0.59.1"
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -1,6 +1,5 @@
-var stifle = require('../index')
-var assert = require('chai').assert
-
+import stifle from '../index.esm'
+import { assert } from 'chai'
 
 describe('stifle', function () {
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,14 @@
 # yarn lockfile v1
 
 
+"@types/estree@0.0.39":
+  version "0.0.39"
+  resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.39.tgz#e177e699ee1b8c22d23174caaa7422644389509f"
+
+"@types/node@*":
+  version "10.1.2"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.1.2.tgz#1b928a0baa408fc8ae3ac012cc81375addc147c6"
+
 assertion-error@^1.0.1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/assertion-error/-/assertion-error-1.1.0.tgz#e60b6b0e8f301bd97e5375215bda406c85118c0b"
@@ -58,6 +66,10 @@ diff@3.2.0:
 escape-string-regexp@1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
+
+esm@^3.0.36:
+  version "3.0.36"
+  resolved "https://registry.yarnpkg.com/esm/-/esm-3.0.36.tgz#3381ae971faf2761908c6c050f1a157225cea964"
 
 fs.realpath@^1.0.0:
   version "1.0.0"
@@ -198,6 +210,13 @@ once@^1.3.0:
 path-is-absolute@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
+
+rollup@^0.59.1:
+  version "0.59.1"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-0.59.1.tgz#86cbceaecd861df1317a0aa29207173de23e6a5d"
+  dependencies:
+    "@types/estree" "0.0.39"
+    "@types/node" "*"
 
 supports-color@3.1.2:
   version "3.1.2"


### PR DESCRIPTION
In this diff I convert source to esm so we can easily use this lib with
native browser modules. This also allow bundlers do not add additional
runtime to work around cjs.

I renamed index.js to index.esm.js and conveted it to esm. Enabled in
tests esm loader which just works. For node users converted to cjs with
rollup.